### PR TITLE
Theme missing features + remove message color property

### DIFF
--- a/src/source.css
+++ b/src/source.css
@@ -9377,10 +9377,14 @@ img[src="/assets/616e078b351d0df460971441949c53a3.svg"] {
 }
 
 /* Invite message */
-.theme-dark .wrapper-35wsBm {
+.theme-dark .wrapper-35wsBm,
+.theme-dark .invite-18yqGF {
   background: rgba(0, 0, 0, 0.2) !important;
   border: 1px solid var(--hover-color) !important;
   border-radius: 12px !important;
+}
+.theme-dark .header-Hg_qNF {
+  color: var(--hover-bright-color) !important;
 }
 
 /* CSS syntax highlighting */

--- a/src/source.css
+++ b/src/source.css
@@ -6329,6 +6329,10 @@ button.button-38aScr.lookLink-9FtZy-.colorPrimary-3b3xI6.sizeMedium-1AC_Sl.grow-
 .theme-dark .lookOutlined-3sRXeN.colorTransparent-1ewNp9 {
   border-color: var(--main-color) !important;
 }
+.detailsBlock-FoDTGA {
+  background-color: rgba(0, 0, 0, 0.6) !important;
+  border: 1px solid var(--hover-color) !important;
+}
 
 /* Settings Overlay */
 .wrapper-3jrx9n {

--- a/src/source.css
+++ b/src/source.css
@@ -5599,6 +5599,9 @@ ul.bda-slist {
 .button-1ZiXG9 {
   color: var(--hover-bright-color) !important;
 }
+.button-1ZiXG9:hover {
+  background-color: var(--hover-color) !important;
+}
 .button-1ZiXG9.dangerous-2r8KxV {
   color: var(--hover-danger-bright-color) !important;
 }

--- a/src/source.css
+++ b/src/source.css
@@ -9811,6 +9811,18 @@ img[src="/assets/616e078b351d0df460971441949c53a3.svg"] {
   background-color: transparent !important;
 }
 
+/* Community Updates popout */
+.theme-dark .popout-6p6fkZ {
+  background-color: rgba(0, 0, 0, 0.9) !important;
+  border: 1px solid var(--hover-color) !important;
+}
+.flowerStarContainer-3zDVtj > svg > path {
+  fill: var(--main-color) !important;
+}
+.staffBadge-3NsEoM {
+  color: hsla(0, 0%, 100%, 0.8) !important;
+}
+
 /* Server Template */
 .descriptionBox-1EKQKL {
   background-color: rgba(0, 0, 0, 0.2) !important;

--- a/src/source.css
+++ b/src/source.css
@@ -12233,6 +12233,18 @@ div[class*="flex-"][class*="title-"],
   background-color: var(--hover-color) !important;
 }
 
+/* Voice channel activity popup */
+.container-2dqNWc {
+  background-color: rgba(0, 0, 0, 0.95) !important;
+  border: 1px solid var(--hover-color) !important;
+}
+.button-uXr0L2 {
+  border-color: var(--main-color) !important;
+}
+.button-uXr0L2:hover {
+  border-color: var(--soft-bright-color) !important;
+}
+
 /* My Account (User Settings) */
 .background-1QDuV2 {
   background-color: rgba(0, 0, 0, 0.4) !important;

--- a/src/source.css
+++ b/src/source.css
@@ -5602,6 +5602,9 @@ ul.bda-slist {
 .button-1ZiXG9:hover {
   background-color: var(--hover-color) !important;
 }
+.button-1ZiXG9:active {
+  background-color: var(--hover-dark-color) !important;
+}
 .button-1ZiXG9.dangerous-2r8KxV {
   color: var(--hover-danger-bright-color) !important;
 }
@@ -9823,6 +9826,57 @@ img[src="/assets/616e078b351d0df460971441949c53a3.svg"] {
 }
 .header-QjU-Vz {
   color: var(--hover-bright-color) !important;
+}
+.exampleContainer-25sB-A {
+  background-color: var(--hover-dark-color) !important;
+}
+.exampleModal-2X2Vf8 {
+  background-color: rgba(0, 0, 0, 0.5) !important;
+}
+.optionContainer-1FtykV {
+  background: var(--hover-color) !important;
+}
+.exampleModal-2X2Vf8 > h3 > strong {
+  color: var(--soft-bright-color) !important;
+}
+.tooltip-1_vJJI {
+  -webkit-box-shadow: none !important;
+  box-shadow: none !important;
+  background-color: var(--main-color) !important;
+  color: var(--soft-bright-color) !important;
+}
+.tooltipPointer-1awMxk {
+  border-right-color: var(--main-color) !important;
+}
+.theme-dark .tooltipBrand-g03Nz8 {
+  color: var(--soft-bright-color) !important;
+  background-color: var(--main-color) !important;
+}
+.theme-dark .tooltipBrand-g03Nz8 .tooltipPointer-3ZfirK {
+  border-top-color: var(--main-color) !important;
+}
+.channelIcon-1eKmlw,
+.channelIcon-g61PDh {
+  background-color: var(--hover-color) !important;
+  color: var(--soft-bright-color) !important;
+}
+.icon-2BoU5V {
+  background-color: var(--hover-color) !important;
+}
+.noIcon-1a_FrS {
+  color: var(--soft-bright-color) !important;
+  background-color: var(--hover-color) !important;
+}
+.welcomeTitle-3SJzU- strong,
+.headerGuildName-2Ur2UW {
+  color: var(--soft-bright-color) !important;
+}
+.optionArrow-2L2fza {
+  color: var(--hover-bright-color) !important;
+}
+.activeCircle-1486wp {
+  background-color: transparent !important;
+  color: var(--soft-bright-color) !important;
 }
 
 /* Server lurk mode */

--- a/src/source.css
+++ b/src/source.css
@@ -9728,7 +9728,6 @@ img[src="/assets/616e078b351d0df460971441949c53a3.svg"] {
 
 /* Community settings */
 .upsellContainer-L9xv7w,
-.upsellFooter-ZYsio_,
 .backgroundAccent-349kuI,
 .checklistContainer-mFJZEJ,
 .checklistHeader-1KWcEY,
@@ -9747,6 +9746,9 @@ img[src="/assets/616e078b351d0df460971441949c53a3.svg"] {
 .text-1ebFA_,
 .base-1x0h_U {
   color: var(--hover-bright-color) !important;
+}
+.upsellFooter-ZYsio_ {
+  background-color: transparent !important;
 }
 
 /* Server Template */

--- a/src/source.css
+++ b/src/source.css
@@ -5598,7 +5598,8 @@ ul.bda-slist {
 .button-1ZiXG9:active {
   background-color: var(--hover-dark-color) !important;
 }
-.button-1ZiXG9.dangerous-2r8KxV {
+.button-1ZiXG9.dangerous-2r8KxV,
+.button-1ZiXG9.selected-LCBEAU {
   color: var(--hover-danger-bright-color) !important;
 }
 

--- a/src/source.css
+++ b/src/source.css
@@ -66,6 +66,7 @@ body {
 
 .colorDefault-2K3EoJ .radioSelection-1HmrQS {
   color: var(--hover-bright-color) !important;
+}
 
 .colorDefault-2K3EoJ .check-1JyqgN {
   color: var(--soft-bright-color) !important;

--- a/src/source.css
+++ b/src/source.css
@@ -7261,7 +7261,7 @@ img:not(.emote):not(.emoji)::after {
   text-indent: 22px !important;
 }
 
-/* Emoji tab */
+/* Emoji/stickers tab */
 .emote::after,
 .emoji::after {
   content: "" !important;

--- a/src/source.css
+++ b/src/source.css
@@ -7349,6 +7349,20 @@ img:not(.emote):not(.emoji)::after {
   color: var(--soft-bright-color) !important;
 }
 
+/* Public server popout */
+.guildPopout-3CgKqR {
+  background-color: rgba(0, 0, 0, 0.85) !important;
+  border: 1px solid var(--hover-color) !important;
+  -webkit-box-shadow: none !important;
+  box-shadow: none !important;
+}
+.iconMask-AFPO7u {
+  background-color: rgba(0, 0, 0, 0.85) !important;
+}
+.footer-3OAEzG {
+  background-color: transparent !important;
+}
+
 /* Member popout discord tag */
 .headerBotTagWithNickname--pvZ2g {
   margin-top: 2px !important;

--- a/src/source.css
+++ b/src/source.css
@@ -5590,7 +5590,8 @@ ul.bda-slist {
 
 /* Message hover toolbar */
 .wrapper-2aW0bm {
-  background-color: var(--hover-color) !important;
+  background: rgba(0, 0, 0, 0.4) !important;
+  border: 1px solid var(--hover-color) !important;
 }
 .button-1ZiXG9 {
   color: var(--hover-bright-color) !important;

--- a/src/source.css
+++ b/src/source.css
@@ -7362,6 +7362,10 @@ img:not(.emote):not(.emoji)::after {
 .footer-3OAEzG {
   background-color: transparent !important;
 }
+.emojiCounter-1BHDd2 {
+  background-color: var(--hover-dark-color) !important;
+  color: var(--soft-bright-color) !important;
+}
 
 /* Member popout discord tag */
 .headerBotTagWithNickname--pvZ2g {

--- a/src/source.css
+++ b/src/source.css
@@ -8772,6 +8772,21 @@ img[src="/assets/616e078b351d0df460971441949c53a3.svg"] {
 .social-links-link .ui-icon-fg {
   fill: #fff !important;
 }
+.item-26Dhrx {
+  background-color: rgba(0, 0, 0, 0.2) !important;
+}
+.item-26Dhrx:hover {
+  background-color: var(--hover-color) !important;
+}
+.item-26Dhrx[aria-checked=true] {
+  background-color: var(--hover-dark-color) !important;
+}
+.title-3BE6m5 {
+  color: var(--soft-bright-color) !important;
+}
+.radioIconForeground-XwlXQN {
+  fill: var(--soft-bright-color) !important;
+}
 
 /* Connection settings */
 .settings-connections-wrapper

--- a/src/source.css
+++ b/src/source.css
@@ -7339,9 +7339,12 @@ img:not(.emote):not(.emoji)::after {
 .none-2Eo-qx::-webkit-scrollbar {
   display: none !important;
 }
-.viewAllBackground-3Bn1vh.stickerBackground-2XECKi {
+.viewAllBackground-3Bn1vh {
   background-color: var(--hover-dark-color) !important;
   color: var(--soft-bright-color) !important;
+}
+.viewAll-2RLt-n:hover .viewAllBackground-3Bn1vh {
+  background-color: var(--hover-bright-color) !important;
 }
 
 /* Emoji */

--- a/src/source.css
+++ b/src/source.css
@@ -6322,6 +6322,40 @@ button.button-38aScr.lookLink-9FtZy-.colorPrimary-3b3xI6.sizeMedium-1AC_Sl.grow-
   text-shadow: none !important;
 }
 
+/* Settings Nitro boosting and gifts */
+.theme-dark .expandedInfo-3kfShd,
+.header-1RC2Wb,
+.guildHeader-3nh5RK,
+.guildSubscriptionSlots-JPXXvN {
+  background-color: rgba(0, 0, 0, 0.4) !important;
+}
+
+/* Settings billing tab */
+.theme-dark .paymentPane-3bwJ6A,
+.theme-dark .paginator-166-09,
+.theme-dark .payment-xT17Mq,
+.paymentRow-2e7VM6 .bottomDivider-1K9Gao {
+  background-color: rgba(0, 0, 0, 0.4) !important;
+  
+}
+.theme-dark .bottomDivider-1K9Gao,
+.theme-dark .summaryInfo-2QFKUg {
+  border-bottom-color: hsla(0, 0%, 100%, 0.04) !important;
+  color: var(--hover-bright-color) !important;
+}
+.pageButtonPrev-1Y-47D,
+.pageButtonPrev-1Y-47D.disabled-BrLY9Y:hover,
+.pageIndicator-1gAbyA,
+.pageButtonNext-V2kUq0,
+.pageButtonNext-V2kUq0.disabled-BrLY9Y:hover {
+  border-color: var(--hover-dark-color) !important;
+  color: var(--hover-dark-color) !important;
+}
+.pageButtonPrev-1Y-47D:hover,
+.pageButtonNext-V2kUq0:hover {
+  border-color: var(--hover-bright-color) !important;
+}
+
 /* Settings Nitro tab */
 .theme-dark .lookOutlined-3sRXeN.colorTransparent-1ewNp9:hover {
   border-color: var(--hover-bright-color) !important;

--- a/src/source.css
+++ b/src/source.css
@@ -59,11 +59,13 @@ body {
 }
 
 /* Miscellaneous */
-.colorDefault-2K3EoJ .checkbox-3s5GYZ,
-.colorDefault-2K3EoJ .radioSelection-1HmrQS {
+.colorDefault-2K3EoJ .checkbox-3s5GYZ {
   color: transparent !important;
   border-color: var(--soft-bright-color) !important;
 }
+
+.colorDefault-2K3EoJ .radioSelection-1HmrQS {
+  color: var(--hover-bright-color) !important;
 
 .colorDefault-2K3EoJ .check-1JyqgN {
   color: var(--soft-bright-color) !important;
@@ -6189,6 +6191,21 @@ button.button-38aScr.lookLink-9FtZy-.colorPrimary-3b3xI6.sizeMedium-1AC_Sl.grow-
 }
 .total-i6us2n:after {
   border-right-color: rgba(0, 0, 0, 0.55) !important;
+}
+
+/* Screenshare and Video */
+.selectorButton-EEUWed {
+  background-color: transparent !important;
+}
+.selectorButtonSelected-t5V9On {
+  background-color: var(--hover-color) !important;
+}
+.tile-2naSqK {
+  background-color: transparent !important;
+}
+.button-3HqqDX {
+  background-color: var(--hover-dark-color) !important;
+  color: var(--soft-bright-color) !important;
 }
 
 /* Select control */

--- a/src/source.css
+++ b/src/source.css
@@ -11555,6 +11555,18 @@ div[class*="flex-"][class*="title-"],
   background-color: var(--main-color) !important;
 }
 
+.errorDetails-qKU8eS {
+  background-color: var(--hover-color) !important;
+}
+
+.gameUpdates-2GPqBU {
+  background-color: var(--hover-color) !important;
+  color: var(--hover-bright-color) !important;
+}
+.nameCellText-Ubz8FY {
+  color: var(--soft-bright-color) !important;
+}
+
 /* Nitro tab */
 .theme-dark .applicationStore-1pNvnv {
   background-color: transparent !important;

--- a/src/source.css
+++ b/src/source.css
@@ -10643,7 +10643,7 @@ img[src="/assets/616e078b351d0df460971441949c53a3.svg"] {
   color: var(--soft-bright-color) !important;
 }
 
-/* Guild vertified badge */
+/* Guild verified badge */
 .guildBadgeWithoutColor-20tGtS {
   color: var(--main-color) !important;
 }
@@ -11570,6 +11570,10 @@ div[class*="flex-"][class*="title-"],
 .theme-dark .scrollerButton-1Vm5_P {
   background-color: var(--hover-color) !important;
 }
+.stickerImageSection-7EUs8E {
+  background-color: transparent !important;
+  border: 1px solid var(--hover-color) !important;
+}
 
 .theme-dark .gradientOverlayLeft-3w159C {
   background-image: -webkit-gradient(
@@ -11807,6 +11811,10 @@ div[class*="flex-"][class*="title-"],
 /* Chat gift menu */
 .theme-dark .option-1l2vXE {
   background-color: var(--hover-color) !important;
+}
+.table-39R0Oe {
+  background-color: transparent !important;
+  border: 1px solid var(--hover-dark-color) !important;
 }
 
 /* Friends tab */

--- a/src/source.css
+++ b/src/source.css
@@ -12097,6 +12097,19 @@ div[class*="flex-"][class*="title-"],
   color: var(--hover-bright-color) !important;
 }
 
+/* Sticker Suggestion popup */
+.containerBackground-3PNziK {
+  background-color: rgba(0, 0, 0.85) !important;
+  border: 1px solid var(--hover-color) !important;
+}
+.maskBackground-1WpXoP {
+  background-color: var(--hover-dark-color) !important;
+}
+.containerBackground-3PNziK:after {
+  border: 7px solid transparent !important;
+  border-top: 7px solid rgba(0, 0, 0, 0.85) !important;
+}
+
 /* Friends tab */
 .theme-dark
   .friendsTable-133bsv

--- a/src/source.css
+++ b/src/source.css
@@ -9725,6 +9725,29 @@ img[src="/assets/616e078b351d0df460971441949c53a3.svg"] {
   background-color: var(--hover-color) !important;
 }
 
+/* Community settings */
+.upsellContainer-L9xv7w,
+.upsellFooter-ZYsio_,
+.backgroundAccent-349kuI,
+.checklistContainer-mFJZEJ,
+.checklistHeader-1KWcEY,
+.checklist-3Y6Fqp,
+.header-2Y0-A-,
+.enableContainer-6E-puu,
+.previewContainer-1SS3uO,
+.welcomeChannel-1rFrIO {
+  background-color: rgba(0, 0, 0, 0.4) !important;
+  color: var(--hover-bright-color) !important;
+}
+.developerPortalCtaWrapper-2XNafh {
+  background-color: var(--hover-color) !important;
+}
+.developerPortalCtaWrapper-2XNafh,
+.text-1ebFA_,
+.base-1x0h_U {
+  color: var(--hover-bright-color) !important;
+}
+
 /* Server Template */
 .descriptionBox-1EKQKL {
   background-color: rgba(0, 0, 0, 0.2) !important;

--- a/src/source.css
+++ b/src/source.css
@@ -6992,6 +6992,14 @@ button.button-38aScr.lookLink-9FtZy-.colorPrimary-3b3xI6.sizeMedium-1AC_Sl.grow-
   opacity: 0.7 !important;
 }
 
+/* Server Rules beginning notice */
+.iconWrapper-2JyIpA {
+  background-color: var(--hover-color) !important;
+}
+.icon-2IcVOj {
+  color: #fff !important;
+}
+
 /* NEW badge */
 .badge-_BgAUQ {
   background-color: var(--hover-color) !important;

--- a/src/source.css
+++ b/src/source.css
@@ -9753,6 +9753,42 @@ img[src="/assets/616e078b351d0df460971441949c53a3.svg"] {
   background-color: rgba(0, 0, 0, 0.2) !important;
 }
 
+/* Server Template Preview */
+.ctaSection-izWwhs,
+.formSection-1NFAGI {
+  background-color: rgba(0, 0, 0, 0.4) !important;
+}
+.channelsWrapper-2HhUER,
+.rolesWrapper-2yOx9S {
+  background-color: transparent !important;
+  border: 1px solid var(--hover-color) !important;
+}
+.usagePill-_nSrnP {
+  background-color: var(--hover-color) !important;
+  color: var(--hover-bright-color) !important;
+}
+.icon-3U3Ats {
+  color: var(--hover-bright-color) !important;
+}
+.icon-3U3Ats > div > svg > circle {
+  fill: var(--hover-bright-color) !important;
+}
+
+/* Welcome Screen */
+.optionContainer-15srkc {
+  background-color: transparent !important;
+  border: 1px solid var(--hover-color) !important;
+}
+.header-QjU-Vz {
+  color: var(--hover-bright-color) !important;
+}
+
+/* Server lurk mode */
+.notice-2X5hT5 {
+  background-color: var(--hover-color) !important;
+  color: var(--soft-bright-color) !important;
+}
+
 /* Server Options button */
 .sidebar-2K8pFh {
   border-radius: 0px !important;

--- a/src/source.css
+++ b/src/source.css
@@ -7228,7 +7228,9 @@ img:not(.emote):not(.emoji)::after {
 .container-2XeR5Z,
 .container-cMG81i,
 .wrapper-2Gsate,
-.wrapper-1-Fsb8 {
+.wrapper-1-Fsb8,
+.wrapper-OxgYJ1,
+.stickerCategoryShopWrapper-3EnJdQ {
   background-color: rgba(0, 0, 0, 0.85) !important;
 }
 .contentWrapper-SvZHNd {
@@ -7236,13 +7238,17 @@ img:not(.emote):not(.emoji)::after {
   border-radius: 8px !important;
 }
 .categoryItemDefaultCategorySelected-_HCKoz,
-.categoryItemDefaultCategorySelected-_HCKoz:hover {
+.categoryItemDefaultCategorySelected-_HCKoz:hover,
+.stickerCategorySelected-2uaMAG,
+.stickerCategorySelected-2uaMAG:hover,
+.stickerCategoryShopWrapperSelected-5VcHEr .stickerCategoryShop-d5zC3B {
   background-color: var(--hover-dark-color) !important;
 }
 .diversitySelectorPopout-3FiGaM {
   border: 1px solid var(--main-color) !important;
 }
-.emojiItem-14v6tW.emojiItemSelected-1aLkfV {
+.emojiItem-14v6tW.emojiItemSelected-1aLkfV,
+.stickerInspected-2EM4w- .stickerBackground-2XECKi {
   background-color: var(--hover-dark-color) !important;
 }
 .medium-2-DE5M .input-1Rv96N,
@@ -7263,11 +7269,16 @@ img:not(.emote):not(.emoji)::after {
   border-top: 1px solid var(--hover-color) !important;
   border-right: 1px solid var(--hover-color) !important;
 }
-.emojiPickerListWrapper-fz8KNK {
+.emojiPickerListWrapper-fz8KNK,
+.scroller-3gAZLs.scrollerBase-289Jih {
   border-top: 1px solid var(--hover-color) !important;
 }
 .none-2Eo-qx::-webkit-scrollbar {
   display: none !important;
+}
+.viewAllBackground-3Bn1vh.stickerBackground-2XECKi {
+  background-color: var(--hover-dark-color) !important;
+  color: var(--soft-bright-color) !important;
 }
 
 /* Emoji */

--- a/src/source.css
+++ b/src/source.css
@@ -5589,9 +5589,14 @@ ul.bda-slist {
 }
 
 /* Message hover toolbar */
-.message-2qnXI6.selected-2P5D_Z .buttons-cl5qTG,
-.mouse-mode .message-2qnXI6:hover .buttons-cl5qTG {
-  visibility: hidden !important;
+.wrapper-2aW0bm {
+  background-color: var(--hover-color) !important;
+}
+.button-1ZiXG9 {
+  color: var(--hover-bright-color) !important;
+}
+.button-1ZiXG9.dangerous-2r8KxV {
+  color: var(--hover-danger-bright-color) !important;
 }
 
 /* Tooltip */

--- a/src/source.css
+++ b/src/source.css
@@ -9490,6 +9490,7 @@ img[src="/assets/616e078b351d0df460971441949c53a3.svg"] {
 .scroller-305q3I,
 .scroller-1JpcIc,
 .scroller-zPkAnE,
+.scroller-2XE8rp,
 .theme-dark .bodyInner-245q0L,
 .theme-dark .footer-1fjuF6,
 .theme-dark .perksModal-fSYqOq {

--- a/src/source.css
+++ b/src/source.css
@@ -12074,6 +12074,24 @@ div[class*="flex-"][class*="title-"],
   background-color: transparent !important;
   border: 1px solid var(--hover-dark-color) !important;
 }
+.select-2fjwPw.lookFilled-22uAsw,
+.popout-VcNcHB {
+  background-color: transparent !important;
+  border: 1px solid var(--hover-color) !important;
+}
+.select-2fjwPw.lookFilled-22uAsw:hover,
+.select-2fjwPw.lookFilled-22uAsw:active {
+  border: 1px solid var(--hover-dark-color) !important;
+}
+.option-3KoAJB[aria-selected=true] {
+  background-color: var(--hover-color) !important;
+}
+.option-3KoAJB {
+  background-color: rgba(0, 0, 0, 0.85) !important;
+}
+.selectedIcon-3uS11H {
+  color: var(--hover-bright-color) !important;
+}
 
 /* Friends tab */
 .theme-dark

--- a/src/source.css
+++ b/src/source.css
@@ -7397,6 +7397,18 @@ img:not(.emote):not(.emoji)::after {
   color: var(--soft-bright-color) !important;
 }
 
+/* Everyone warning popout */
+.everyonePopout-nEbJY3 {
+  background-color: rgba(0, 0, 0, 0.95) !important;
+  border: 1px solid var(--hover-color) !important;
+}
+.footer-2aTx0s {
+  background-color: transparent !important;
+}
+.icon-2qOzDL > g > path {
+  color: var(--soft-bright-color) !important;
+}
+
 /* Member popout discord tag */
 .headerBotTagWithNickname--pvZ2g {
   margin-top: 2px !important;

--- a/src/source.css
+++ b/src/source.css
@@ -10325,7 +10325,6 @@ img[src="/assets/616e078b351d0df460971441949c53a3.svg"] {
 /* Message text */
 .theme-dark .message-group .comment .markup,
 .markup-2BOw-j {
-  color: hsla(0, 0%, 100%, 0.8) !important;
   font-size: 0.95rem !important;
   /* margin-top: 0px  !important; */
 }

--- a/src/source.css
+++ b/src/source.css
@@ -9852,6 +9852,9 @@ img[src="/assets/616e078b351d0df460971441949c53a3.svg"] {
 .upsellFooter-ZYsio_ {
   background-color: transparent !important;
 }
+.featureIcon-3p1TC_ > svg > path {
+  fill: var(--soft-bright-color) !important;
+}
 
 /* Community Updates popout */
 .theme-dark .popout-6p6fkZ {


### PR DESCRIPTION
Proposing this change mainly because of the recent Discord outage that led messages failing to send. This makes it hard for the user to notice the messages actually failed to send because they don't turn red when it does as seen here:
![color](https://user-images.githubusercontent.com/18041538/99203956-04018a00-27ac-11eb-892e-c2bf44d528ca.png)
